### PR TITLE
Use flexbox CSS for improved dynamic width

### DIFF
--- a/gh-pr.css
+++ b/gh-pr.css
@@ -1,0 +1,18 @@
+#files {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
+#file-tree {
+  flex-basis: 20%;
+  /* max-width: 20%; */
+  padding-right: 10px;
+  align-self: flex-start;
+}
+
+.js-diff-progressive-container {
+  flex-basis: 80%;
+  /* max-width: 80%; */
+  align-self: flex-end;
+}

--- a/gh-pr.js
+++ b/gh-pr.js
@@ -10,15 +10,7 @@ function insertTreeView(filesBucket) {
   var treeData = buildTree(paths);
 
   // Update HTML and render tree view
-  $('.js-diff-progressive-container').css({
-    'margin-left': '365px'
-  })
   var fileTree = $('<div id="file-tree"></div>');
-  fileTree.css({
-    width: '350px',
-    margin: 0,
-    float: 'left'
-  });
   filesBucket.find('#files').prepend(fileTree);
   fileTree.tree({ data: treeData });
 }


### PR DESCRIPTION
Not quite right yet (my flexbox is a little rusty) - setting `max-width` will keep it strictly at a 20/80 spread regardless of how small the tree may be at start, but removing them pushes the `.js-diff-progressive-container` elements to the right (in unified view).